### PR TITLE
Fix doppelganger check

### DIFF
--- a/templates/lighthouse-vc.service.j2
+++ b/templates/lighthouse-vc.service.j2
@@ -20,7 +20,7 @@ ExecStart={{ lighthouse_bin }} \
 	{% if lighthouse_validator_beacon_nodes is defined %}
 	--beacon-nodes {{ lighthouse_validator_beacon_nodes }} \
 	{% endif %}
-	{% if lighthouse_validator_enable_doppelganger_protection is defined %}
+	{% if lighthouse_validator_enable_doppelganger_protection == True %}
 	--enable-doppelganger-protection \
 	{% endif %}
 	{% if lighthouse_validator_beacon_nodes_tls_certs is defined %}


### PR DESCRIPTION
Setting `lighthouse_validator_enable_doppelganger_protection` to `False` was ineffective because the check was for existence rather than truthyness